### PR TITLE
Issue #7: Add reproducible seed handling for simulate

### DIFF
--- a/docs/ai_test_play.md
+++ b/docs/ai_test_play.md
@@ -34,6 +34,18 @@ npm run simulate -- --single --ai 2 --minutes 5 --difficulty normal
 npm run simulate -- --single --ai 5 --minutes 10 --difficulty normal
 ```
 
+### seed 指定で再現実行
+
+```bash
+npm run simulate -- --single --ai 20 --minutes 10 --difficulty normal --seed 12345
+npm run simulate -- --seed 12345
+```
+
+- 出力 JSON の `seed` を保存しておくと、同条件で再現できる。
+- `--seed` 未指定時も、実際に使われた `seed` は結果に出力される。
+- デフォルト2シナリオ時は `seed=base` と `seed=base+1` が使われる。
+- `--seed` は `uint32 (0..4294967295)` として正規化して利用される。
+
 ## 出力の見方
 
 JSON 1行ごとに1シナリオ結果を出す。
@@ -41,6 +53,7 @@ JSON 1行ごとに1シナリオ結果を出す。
 主要フィールド:
 
 - `reason`: 終了理由 (`victory|timeout|all_down|collapse`)
+- `seed`: 実行に使った乱数seed（再現実行用）
 - `maxCapture`: 最大制覇率
 - `minCaptureAfter70`: 制覇率70%到達後の最低制覇率
 - `downs`, `rescues`: 被弾と立て直し傾向

--- a/docs/dev/simulate-seed-reproducibility/design.md
+++ b/docs/dev/simulate-seed-reproducibility/design.md
@@ -1,0 +1,29 @@
+# Design: simulate-seed-reproducibility
+
+## 方針
+
+- 既存 CLI 解析に `--seed` を追加する。
+- `Scenario` に `seed` を持たせ、`GameEngine` 初期化時にその値を渡す。
+- 出力 JSON に `seed` を追加し、再実行しやすくする。
+
+## 仕様
+
+1. `--seed` 指定時
+   - `--single` の場合: その seed を使う。
+   - デフォルト2シナリオの場合: 1件目に base seed、2件目に base seed + 1 を使う。
+2. `--seed` 未指定時
+   - `Date.now()` を base seed として採用する。
+   - 実際に使った seed は結果 JSON に必ず含める。
+3. `--seed` の入力検証
+   - `--seed` 指定時に値が欠落/非数値ならエラー終了する。
+4. seed 正規化
+   - 実際に使う seed は `uint32` (`0..4294967295`) に正規化する。
+
+## 影響範囲
+
+- `src/server/simulate.ts`
+  - `Scenario`/`ScenarioResult` に `seed` 追加
+  - 引数解析 (`--seed`) 追加
+  - 出力 JSON へ `seed` 追加
+- `docs/ai_test_play.md`
+  - seed 指定による再現実行手順を追記

--- a/docs/dev/simulate-seed-reproducibility/requirements.md
+++ b/docs/dev/simulate-seed-reproducibility/requirements.md
@@ -1,0 +1,18 @@
+# Requirements: simulate-seed-reproducibility
+
+## 背景
+
+- `src/server/simulate.ts` は内部 seed に `Date.now()` を使っているため、同条件での再現実行が難しい。
+- 異常値やバランス崩れを再検証したい時に、同じ条件を完全再現したい。
+
+## 要求
+
+1. `npm run simulate -- --seed <number>` を受け付けること。
+2. seed 未指定時も、実行に使った seed を結果に出力すること。
+3. デフォルト2シナリオ実行時は、各シナリオに使った seed が明示されること。
+4. 手順書 (`docs/ai_test_play.md`) に seed を使った再現方法を追記すること。
+
+## 非要求
+
+- シミュレーションロジックのゲームバランス調整はこの対応対象外。
+- `npm run simulate` の既存引数 (`--single --ai --minutes --difficulty`) の仕様変更はしない。

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -68,7 +68,13 @@ npm run simulate
 
 ```bash
 npm run simulate -- --single --ai 5 --minutes 10 --difficulty normal
+npm run simulate -- --single --ai 20 --minutes 10 --difficulty normal --seed 12345
 ```
+
+再現実行メモ:
+
+- `--seed` を指定すると同条件を再現しやすくなる。
+- `--seed` 未指定でも出力JSONに `seed` が出るため、後から同値で再実行できる。
 
 ## 操作方法
 

--- a/src/server/helpers.ts
+++ b/src/server/helpers.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+let idSequence = 0;
 
 export function keyOf(x: number, y: number): string {
   return `${x},${y}`;
@@ -10,7 +10,8 @@ export function parseKey(key: string): { x: number; y: number } {
 }
 
 export function makeId(prefix: string): string {
-  return `${prefix}_${randomUUID().slice(0, 8)}`;
+  idSequence = (idSequence + 1) >>> 0;
+  return `${prefix}_${idSequence.toString(36).padStart(8, '0')}`;
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/src/server/simulate.ts
+++ b/src/server/simulate.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { TICK_MS } from '../shared/constants.js';
 import type { Difficulty, Snapshot } from '../shared/types.js';
 import { GameEngine, type StartPlayer } from './game.js';
@@ -8,10 +7,12 @@ interface Scenario {
   aiPlayers: number;
   minutes: number;
   difficulty: Difficulty;
+  seed: number;
 }
 
 interface ScenarioResult {
   scenario: Scenario;
+  seed: number;
   ticks: number;
   ended: boolean;
   reason: string;
@@ -46,11 +47,11 @@ function runScenario(scenario: Scenario): ScenarioResult {
   const startPlayers: StartPlayer[] = Array.from({ length: scenario.aiPlayers }, (_, idx) => ({
     id: `ai_${idx + 1}`,
     name: `AI-${(idx + 1).toString().padStart(2, '0')}`,
-    reconnectToken: randomUUID(),
+    reconnectToken: `sim_${scenario.seed}_${idx + 1}`,
     connected: false,
   }));
 
-  const engine = new GameEngine(startPlayers, scenario.difficulty, Date.now(), {
+  const engine = new GameEngine(startPlayers, scenario.difficulty, scenario.seed, {
     timeLimitMsOverride: scenario.minutes * 60_000,
   });
 
@@ -114,6 +115,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
 
   return {
     scenario,
+    seed: scenario.seed,
     ticks,
     ended: engine.isEnded(),
     reason: summary.reason,
@@ -169,6 +171,7 @@ function validateSnapshot(snapshot: Snapshot, anomalies: string[]): void {
 function printScenarioResult(result: ScenarioResult): void {
   const line = {
     scenario: result.scenario.name,
+    seed: result.seed,
     aiPlayers: result.scenario.aiPlayers,
     minutes: result.scenario.minutes,
     difficulty: result.scenario.difficulty,
@@ -193,6 +196,7 @@ function resolveScenarios(args: string[]): Scenario[] {
   const ai = readArgNumber(args, '--ai');
   const minutes = readArgNumber(args, '--minutes');
   const difficulty = (readArgString(args, '--difficulty') as Difficulty | null) ?? 'normal';
+  const baseSeed = parseSeedOrExit(args);
 
   if (ai !== null || minutes !== null || args.includes('--single')) {
     return [
@@ -201,13 +205,14 @@ function resolveScenarios(args: string[]): Scenario[] {
         aiPlayers: clamp(ai ?? 2, 1, 100),
         minutes: clamp(minutes ?? 3, 1, 10),
         difficulty,
+        seed: baseSeed,
       },
     ];
   }
 
   return [
-    { name: 'quick-check-ai2', aiPlayers: 2, minutes: 2, difficulty: 'normal' },
-    { name: 'balance-check-ai5', aiPlayers: 5, minutes: 5, difficulty: 'normal' },
+    { name: 'quick-check-ai2', aiPlayers: 2, minutes: 2, difficulty: 'normal', seed: baseSeed },
+    { name: 'balance-check-ai5', aiPlayers: 5, minutes: 5, difficulty: 'normal', seed: nextSeed(baseSeed, 1) },
   ];
 }
 
@@ -230,4 +235,33 @@ function readArgString(args: string[], name: string): string | null {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function parseSeedOrExit(args: string[]): number {
+  const idx = args.indexOf('--seed');
+  if (idx < 0) {
+    return normalizeSeed(Date.now());
+  }
+
+  const rawValue = args[idx + 1];
+  if (!rawValue) {
+    console.error('ERROR: --seed requires a numeric value');
+    process.exit(1);
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed)) {
+    console.error(`ERROR: --seed must be a number, got "${rawValue}"`);
+    process.exit(1);
+  }
+
+  return normalizeSeed(parsed);
+}
+
+function normalizeSeed(seed: number): number {
+  return Math.floor(seed) >>> 0;
+}
+
+function nextSeed(seed: number, offset: number): number {
+  return normalizeSeed(seed + offset);
 }


### PR DESCRIPTION
## Summary
- add `--seed` support to `simulate` and include the effective seed in output JSON
- make seed parsing strict (`--seed` missing/invalid value -> error exit)
- normalize seeds as `uint32` and use deterministic id generation for server runtime IDs
- add requirement/design docs under `docs/dev/simulate-seed-reproducibility/`
- document seed-based replay in `docs/ai_test_play.md` and `docs/local_development.md`

## Issue
- refs #7

## Validation
- `npm run check`
- `npm run build`
- `npm run simulate -- --single --ai 20 --minutes 10 --difficulty normal --seed 12345`
- same-seed replay produced identical JSON output
- invalid seed (`--seed foo`) exits with error

## my-review
- executed twice with 30m timeout
- reflected findings: strict seed validation, uint32 normalization, doc clarifications, deterministic ID generation
