### PR TITLE
Issue #3: Add regression selftests for server behaviors

### DIFF
--- a/docs/dev/regression-test-suite/design.md
+++ b/docs/dev/regression-test-suite/design.md
@@ -1,0 +1,27 @@
+# Design: regression-test-suite
+
+## 方針
+
+- 既存運用に合わせ、`tsx` で実行する selftest スタイルを拡張する。
+- private ロジックも回帰検知できるよう、`any` 経由で内部メソッドへアクセスするテストを最小限追加する。
+
+## 追加テスト
+
+1. `src/server/game.selftest.ts` (新規)
+   - swap 衝突判定: `resolveGhostCollisions` がすれ違いを検知する
+   - dot 再生成セル判定: gate/switch/pellet を除外する
+   - auto respawn: grace が付与される
+   - `step()` 経由の統合寄りテスト（衝突/autoRespawn発火）
+2. `src/server/reconnect.selftest.ts` (新規)
+   - `getPlayerByToken` と `setPlayerConnection` の回帰確認
+3. `package.json`
+   - `test` スクリプトに `test:server-game` を追加
+   - `test:server-reconnect` を追加
+
+## ドキュメント
+
+- `docs/local_development.md` に `npm test` の説明を追記する。
+
+## 補足
+
+- `server/index.ts` の reconnect/host まわりの WebSocket 統合テストは次フェーズで専用テスト基盤を追加する前提。

--- a/docs/dev/regression-test-suite/requirements.md
+++ b/docs/dev/regression-test-suite/requirements.md
@@ -1,0 +1,22 @@
+# Requirements: regression-test-suite
+
+## 背景
+
+- 既存の `check/build/simulate` だけでは、再接続・衝突・再生成などの境界条件回帰を早期検知しづらい。
+- 直近で修正した高リスク領域に対して、固定テストケースを増やす必要がある。
+
+## 要求
+
+1. `npm test` で複数の自己テストを実行できる状態にする。
+2. 以下の高リスク観点に対して回帰テストを追加する。
+   - reconnect関連（token検索/接続状態反映）
+   - swap 衝突検知
+   - dot 再生成セルの妥当性（gate/switch/pellet除外）
+   - auto respawn の grace 付与
+3. テスト追加後も `check/build/test` が通ること。
+4. テスト方針を docs に明文化すること。
+
+## 非要求
+
+- 本格的なE2E基盤導入（Playwright等）はこのIssueでは行わない。
+- 全コードパス網羅は目標にしない。

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -45,6 +45,12 @@ npm run start
 npm run check
 ```
 
+## 自動テスト
+
+```bash
+npm run test
+```
+
 ## AI-onlyテストプレイ（UI）
 
 1. ブラウザで `http://localhost:5173` を開く

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "build:client": "vite build",
     "build:server": "tsc -p tsconfig.server.json",
     "check": "tsc -p tsconfig.server.json --noEmit && tsc -p tsconfig.client.json --noEmit",
-    "test": "npm run test:client-parser && npm run test:server-loop",
+    "test": "npm run test:client-parser && npm run test:server-loop && npm run test:server-game && npm run test:server-reconnect",
     "test:client-parser": "tsx src/client/parseServerMessage.selftest.ts",
     "test:server-loop": "tsx src/server/loop.selftest.ts",
+    "test:server-game": "tsx src/server/game.selftest.ts",
+    "test:server-reconnect": "tsx src/server/reconnect.selftest.ts",
     "simulate": "tsx src/server/simulate.ts",
     "start": "node dist/server/server/index.js"
   },

--- a/src/server/game.selftest.ts
+++ b/src/server/game.selftest.ts
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import { keyOf } from './helpers.js';
+import { GameEngine, type StartPlayer } from './game.js';
+
+interface TestEngine {
+  players: Map<string, any>;
+  ghosts: Map<string, any>;
+  world: {
+    sectors: Array<{ id: number; floorCells: Array<{ x: number; y: number }> }>;
+    dots: Set<string>;
+    gates: Array<{
+      id: string;
+      a: { x: number; y: number };
+      b: { x: number; y: number };
+      switchA: { x: number; y: number };
+      switchB: { x: number; y: number };
+      open: boolean;
+      permanent: boolean;
+    }>;
+    powerPellets: Map<
+      string,
+      {
+        key: string;
+        x: number;
+        y: number;
+        active: boolean;
+        respawnAt: number;
+      }
+    >;
+  };
+  startedAtMs: number;
+  step: (dtMs: number) => void;
+  resolveGhostCollisions: (
+    nowMs: number,
+    playerPositionsBeforeMove: Map<string, { x: number; y: number }>,
+    ghostPositionsBeforeMove: Map<string, { x: number; y: number }>,
+  ) => void;
+  isValidDotRespawnCell: (sectorId: number, x: number, y: number) => boolean;
+  autoRespawn: (player: any, nowMs: number) => void;
+}
+
+function createEngine(seed: number): TestEngine {
+  const players: StartPlayer[] = [
+    {
+      id: 'p1',
+      name: 'P1',
+      reconnectToken: 'token_p1',
+      connected: true,
+    },
+  ];
+  return new GameEngine(players, 'normal', seed, { timeLimitMsOverride: 180_000 }) as unknown as TestEngine;
+}
+
+function keepSingleGhost(engine: TestEngine): any {
+  const firstGhost = engine.ghosts.values().next().value;
+  assert.ok(firstGhost);
+  for (const ghost of Array.from(engine.ghosts.values())) {
+    if (ghost.id !== firstGhost.id) {
+      engine.ghosts.delete(ghost.id);
+    }
+  }
+  return firstGhost;
+}
+
+function findBaselineRespawnCell(engine: TestEngine, sectorId: number): { x: number; y: number } {
+  const sector = engine.world.sectors.find((item) => item.id === sectorId);
+  assert.ok(sector);
+
+  for (const cell of sector.floorCells) {
+    const key = keyOf(cell.x, cell.y);
+    const hadDot = engine.world.dots.delete(key);
+    const pellet = engine.world.powerPellets.get(key);
+    if (pellet) {
+      engine.world.powerPellets.delete(key);
+    }
+
+    const isValid = engine.isValidDotRespawnCell(sectorId, cell.x, cell.y);
+
+    if (hadDot) {
+      engine.world.dots.add(key);
+    }
+    if (pellet) {
+      engine.world.powerPellets.set(key, pellet);
+    }
+
+    if (isValid) {
+      return { x: cell.x, y: cell.y };
+    }
+  }
+
+  throw new Error('No baseline respawn cell found');
+}
+
+function prepareCellAsRespawnCandidate(engine: TestEngine, cell: { x: number; y: number }): void {
+  const key = keyOf(cell.x, cell.y);
+  engine.world.dots.delete(key);
+  engine.world.powerPellets.delete(key);
+}
+
+function testSwapCollision(): void {
+  const engine = createEngine(11);
+  const player = engine.players.get('p1');
+  assert.ok(player);
+  const firstGhost = keepSingleGhost(engine);
+
+  player.state = 'normal';
+  player.remoteReviveGraceUntil = 0;
+  player.downSince = null;
+
+  // Negative case: no overlap/swap should keep player alive.
+  player.x = 20;
+  player.y = 20;
+  firstGhost.x = 24;
+  firstGhost.y = 20;
+  engine.resolveGhostCollisions(
+    engine.startedAtMs + 500,
+    new Map([[player.id, { x: 20, y: 20 }]]),
+    new Map([[firstGhost.id, { x: 24, y: 20 }]]),
+  );
+  assert.equal(player.state, 'normal');
+
+  // Positive case: swap positions in one tick should down the player.
+  const playerBefore = { x: 10, y: 10 };
+  const ghostBefore = { x: 11, y: 10 };
+  player.x = 11;
+  player.y = 10;
+  firstGhost.x = 10;
+  firstGhost.y = 10;
+
+  engine.resolveGhostCollisions(
+    engine.startedAtMs + 1000,
+    new Map([[player.id, playerBefore]]),
+    new Map([[firstGhost.id, ghostBefore]]),
+  );
+
+  assert.equal(player.state, 'down');
+}
+
+function testRespawnCellValidation(): void {
+  // Gate exclusion
+  {
+    const engine = createEngine(13);
+    const sector = engine.world.sectors[0];
+    assert.ok(sector);
+    const cell = findBaselineRespawnCell(engine, sector.id);
+    prepareCellAsRespawnCandidate(engine, cell);
+    assert.equal(engine.isValidDotRespawnCell(sector.id, cell.x, cell.y), true);
+
+    engine.world.gates.push({
+      id: 'gate_test',
+      a: { x: cell.x, y: cell.y },
+      b: { x: cell.x, y: cell.y },
+      switchA: { x: cell.x, y: cell.y },
+      switchB: { x: cell.x, y: cell.y },
+      open: false,
+      permanent: false,
+    });
+    assert.equal(engine.isValidDotRespawnCell(sector.id, cell.x, cell.y), false);
+  }
+
+  // Switch exclusion
+  {
+    const engine = createEngine(14);
+    const sector = engine.world.sectors[0];
+    assert.ok(sector);
+    const cell = findBaselineRespawnCell(engine, sector.id);
+    prepareCellAsRespawnCandidate(engine, cell);
+    assert.equal(engine.isValidDotRespawnCell(sector.id, cell.x, cell.y), true);
+
+    engine.world.gates.push({
+      id: 'switch_test',
+      a: { x: 0, y: 0 },
+      b: { x: 0, y: 0 },
+      switchA: { x: cell.x, y: cell.y },
+      switchB: { x: 0, y: 0 },
+      open: false,
+      permanent: false,
+    });
+    assert.equal(engine.isValidDotRespawnCell(sector.id, cell.x, cell.y), false);
+  }
+
+  // Pellet exclusion
+  {
+    const engine = createEngine(15);
+    const sector = engine.world.sectors[0];
+    assert.ok(sector);
+    const cell = findBaselineRespawnCell(engine, sector.id);
+    prepareCellAsRespawnCandidate(engine, cell);
+    assert.equal(engine.isValidDotRespawnCell(sector.id, cell.x, cell.y), true);
+
+    const pelletKey = keyOf(cell.x, cell.y);
+    engine.world.powerPellets.set(pelletKey, {
+      key: pelletKey,
+      x: cell.x,
+      y: cell.y,
+      active: true,
+      respawnAt: 0,
+    });
+    assert.equal(engine.isValidDotRespawnCell(sector.id, cell.x, cell.y), false);
+  }
+}
+
+function testAutoRespawnGrace(): void {
+  const engine = createEngine(17);
+  const player = engine.players.get('p1');
+  assert.ok(player);
+  const firstGhost = keepSingleGhost(engine);
+
+  const nowMs = engine.startedAtMs + 20_000;
+  player.state = 'down';
+  player.downSince = nowMs - 10_000;
+  player.remoteReviveGraceUntil = 0;
+
+  engine.autoRespawn(player, nowMs);
+
+  assert.equal(player.state, 'normal');
+  assert.ok(player.remoteReviveGraceUntil > nowMs);
+
+  firstGhost.x = player.x;
+  firstGhost.y = player.y;
+  engine.resolveGhostCollisions(
+    nowMs + 1_000,
+    new Map([[player.id, { x: player.x, y: player.y }]]),
+    new Map([[firstGhost.id, { x: firstGhost.x, y: firstGhost.y }]]),
+  );
+  assert.equal(player.state, 'normal');
+
+  engine.resolveGhostCollisions(
+    nowMs + 2_500,
+    new Map([[player.id, { x: player.x, y: player.y }]]),
+    new Map([[firstGhost.id, { x: firstGhost.x, y: firstGhost.y }]]),
+  );
+  assert.equal(player.state, 'down');
+}
+
+function testStepCollisionIntegration(): void {
+  const engine = createEngine(21);
+  const player = engine.players.get('p1');
+  assert.ok(player);
+  const ghost = keepSingleGhost(engine);
+
+  player.state = 'normal';
+  player.remoteReviveGraceUntil = 0;
+  player.downSince = null;
+  player.moveBuffer = 0;
+  player.desiredDir = 'none';
+  player.dir = 'none';
+
+  player.x = ghost.x;
+  player.y = ghost.y;
+
+  engine.step(0);
+  assert.equal(player.state, 'down');
+}
+
+function testStepAutoRespawnIntegration(): void {
+  const engine = createEngine(23);
+  const player = engine.players.get('p1');
+  assert.ok(player);
+
+  player.state = 'down';
+  player.downSince = engine.startedAtMs - 100_000;
+  player.remoteReviveGraceUntil = 0;
+
+  engine.step(0);
+  assert.equal(player.state, 'normal');
+  assert.ok(player.remoteReviveGraceUntil > engine.startedAtMs);
+}
+
+function run(): void {
+  testSwapCollision();
+  testRespawnCellValidation();
+  testAutoRespawnGrace();
+  testStepCollisionIntegration();
+  testStepAutoRespawnIntegration();
+  console.log('server game selftest: OK');
+}
+
+run();

--- a/src/server/reconnect.selftest.ts
+++ b/src/server/reconnect.selftest.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { GameEngine, type StartPlayer } from './game.js';
+
+function run(): void {
+  const players: StartPlayer[] = [
+    {
+      id: 'p1',
+      name: 'P1',
+      reconnectToken: 'token_p1',
+      connected: true,
+    },
+  ];
+  const engine: any = new GameEngine(players, 'normal', 31, { timeLimitMsOverride: 60_000 });
+
+  const byToken = engine.getPlayerByToken('token_p1');
+  assert.ok(byToken);
+  assert.equal(byToken.id, 'p1');
+
+  engine.setPlayerConnection('p1', false);
+  assert.equal(byToken.connected, false);
+  assert.equal(byToken.ai, true);
+
+  engine.setPlayerConnection('p1', true);
+  assert.equal(byToken.connected, true);
+  assert.equal(byToken.ai, false);
+
+  console.log('server reconnect selftest: OK');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add server regression selftests for high-risk game behavior
  - swap collision (negative/positive)
  - respawn cell validation with positive control and independent gate/switch/pellet checks
  - auto respawn grace (before/after expiry)
  - step-path integration checks (collision and auto-respawn)
  - reconnect-related checks (`getPlayerByToken`, `setPlayerConnection`)
- wire new tests into `npm test`
- add requirements/design docs under `docs/dev/regression-test-suite/`
- document `npm test` in local development guide

## Issue
- refs #3

## Validation
- `npm run check`
- `npm run build`
- `npm run test`

## my-review
- executed twice with 30m timeout
- reflected findings: stronger positive control, reduced false positives, reconnect coverage, integration-path checks via `step()`
