### PR TITLE
[Ops] 監視/ログ整備

### DIFF
--- a/docs/dev/ops-structured-logging/design.md
+++ b/docs/dev/ops-structured-logging/design.md
@@ -1,0 +1,33 @@
+# Design: ops-structured-logging
+
+## Overview
+`rust/server/src/bin/simulate.rs` に構造化ログの共通フォーマットを追加し、
+- 試合開始/終了
+- 異常検知
+- 実行サマリ
+を JSONL で出力する。必要に応じてサマリをファイルへ保存できるようにする。
+
+## CLI Changes
+- `--match-id <string>`: ログ集約キー。未指定時は seed/時刻から自動生成。
+- `--summary-out <path>`: 全シナリオ完了後の集約サマリ JSON を保存。
+
+## Data Model
+- `StructuredLogLine`
+  - `level`: `info|warn|error`
+  - `event`: `scenario_started|scenario_finished|anomaly_detected|run_finished`
+  - `matchId`, `scenario`, `seed`, `tick`
+  - `details`: 可変メタデータ
+- `RunSummary`
+  - 各シナリオ結果（既存 `ScenarioResultLine`）
+  - 集計値（異常件数、終了理由別件数、平均試合時間）
+
+## Validation Plan
+1. `npm run check`
+2. `npm run build`
+3. `npm run test`
+4. `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
+5. `cargo run --manifest-path rust/server/Cargo.toml --bin simulate -- --single --ai 5 --minutes 3 --difficulty normal --seed 42 --match-id local-test --summary-out /tmp/mmo-packman-summary.json`
+
+## Rollout Notes
+- 既存の JSON result line は維持し、追加ログを同時出力する。
+- Cloud Run では `event` フィールドでフィルタし、`anomaly_detected` を重点監視する。

--- a/docs/dev/ops-structured-logging/requirements.md
+++ b/docs/dev/ops-structured-logging/requirements.md
@@ -1,0 +1,18 @@
+# Requirements: ops-structured-logging
+
+## Goal
+Rust simulator の実行ログを機械可読で収集できるようにし、異常検知と試合サマリ取得を標準化する。
+
+## Functional Requirements
+1. `simulate` 実行時に、試合単位で `matchId/seed/tick` を含む構造化ログを出力できること。
+2. 異常検知時に、内容だけでなく発生 tick もログへ記録できること。
+3. 試合サマリを JSON 形式で一括取得できること（stdout かファイル出力）。
+4. 監視手順（ローカル/Cloud Run 想定）を `docs/operation_notes.md` か `docs/deployment_cloud_run.md` に追記すること。
+
+## Non-Functional Requirements
+- 既存の `simulate` 利用フローを壊さず、CI/ローカルで追加依存なしで動くこと。
+- ログ1行を JSON object とし、`jq` などの一般的 CLI で集計できること。
+
+## Out of Scope
+- 外部APM/監視SaaSとの自動連携
+- WebSocket サーバー本体の監視実装

--- a/docs/operation_notes.md
+++ b/docs/operation_notes.md
@@ -34,3 +34,50 @@
 3. 簡易リプレイ（タイムライン + 俯瞰再生）
 4. 永続戦績（ランキング）
 5. 監視/ログ整備
+
+## 監視/ログ運用（Rust simulate）
+
+### 構造化ログ
+
+- `simulate` は stderr に JSONL で構造化ログを出力する。
+- `matchId` 未指定時は `sim-<seed>-<timestamp_ms>` が自動採番される。
+- 主要イベント:
+  - `scenario_started`
+  - `anomaly_detected`
+  - `scenario_finished`
+  - `run_finished`
+  - `summary_write_failed`（`--summary-out` 書き込み失敗時）
+- ログ共通フィールド:
+  - `matchId`: 実行単位ID（`--match-id` で指定可）
+  - `scenario`: シナリオ名
+  - `seed`: シナリオseed
+  - `tick`: 異常/終了時のtick
+
+実行例:
+
+```bash
+cargo run --quiet --manifest-path rust/server/Cargo.toml --bin simulate -- \
+  --single --ai 5 --minutes 3 --difficulty normal --seed 42 --match-id ops-check \
+  --summary-out /tmp/mmo-packman-summary.json \
+  1>/tmp/mmo-packman-result.jsonl 2>/tmp/mmo-packman-log.jsonl
+```
+
+異常検知だけを抽出:
+
+```bash
+jq -c 'select(.event=="anomaly_detected")' /tmp/mmo-packman-log.jsonl
+```
+
+### 試合サマリ（機械可読）
+
+- `--summary-out <path>` を指定すると、実行全体の集約サマリ JSON を出力する。
+- サマリには以下を含む:
+  - `scenarioCount`, `anomalyCount`, `averageDurationMs`
+  - `reasonCounts`（終了理由ごとの件数）
+  - `scenarios`（シナリオ別の詳細結果）
+
+### Cloud Run 想定の最低限監視
+
+- Cloud Logging で `event="anomaly_detected"` をログベースメトリクス化する。
+- `event="run_finished"` の `averageDurationMs` / `reasonCounts` を定期確認する。
+- `matchId` をデプロイ単位・検証バッチ単位で付与し、問題発生時に追跡可能にする。

--- a/rust/server/src/bin/simulate.rs
+++ b/rust/server/src/bin/simulate.rs
@@ -1,8 +1,16 @@
 use clap::Parser;
 use mmo_packman_rust_server::constants::TICK_MS;
 use mmo_packman_rust_server::engine::{GameEngine, GameEngineOptions};
-use mmo_packman_rust_server::types::{Difficulty, RuntimeEvent, Snapshot, StartPlayer};
+use mmo_packman_rust_server::types::{
+    Difficulty, GameOverReason, RuntimeEvent, Snapshot, StartPlayer,
+};
 use serde::Serialize;
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, HashSet};
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -17,6 +25,10 @@ struct Cli {
     difficulty: Option<String>,
     #[arg(long)]
     seed: Option<u64>,
+    #[arg(long)]
+    match_id: Option<String>,
+    #[arg(long)]
+    summary_out: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -37,7 +49,9 @@ struct ScenarioResultLine {
     ai_players: usize,
     minutes: i32,
     difficulty: Difficulty,
-    reason: mmo_packman_rust_server::types::GameOverReason,
+    reason: GameOverReason,
+    #[serde(rename = "durationMs")]
+    duration_ms: u64,
     #[serde(rename = "maxCapture")]
     max_capture: f32,
     #[serde(rename = "minCaptureAfter70")]
@@ -59,28 +73,186 @@ struct ScenarioResultLine {
     anomalies: Vec<String>,
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct AnomalyRecord {
+    tick: u64,
+    message: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ScenarioRunResult {
+    #[serde(flatten)]
+    result: ScenarioResultLine,
+    #[serde(rename = "anomalyRecords")]
+    anomaly_records: Vec<AnomalyRecord>,
+    finished_tick: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RunSummary {
+    #[serde(rename = "matchId")]
+    match_id: String,
+    #[serde(rename = "startedAtMs")]
+    started_at_ms: u64,
+    #[serde(rename = "finishedAtMs")]
+    finished_at_ms: u64,
+    #[serde(rename = "scenarioCount")]
+    scenario_count: usize,
+    #[serde(rename = "anomalyCount")]
+    anomaly_count: usize,
+    #[serde(rename = "averageDurationMs")]
+    average_duration_ms: u64,
+    #[serde(rename = "reasonCounts")]
+    reason_counts: BTreeMap<String, usize>,
+    scenarios: Vec<ScenarioResultLine>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct StructuredLogLine {
+    #[serde(rename = "timestampMs")]
+    timestamp_ms: u64,
+    level: String,
+    event: String,
+    #[serde(rename = "matchId")]
+    match_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scenario: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tick: Option<u64>,
+    details: Value,
+}
+
 fn main() {
     let cli = Cli::parse();
     let scenarios = resolve_scenarios(&cli);
+    let run_started_at_ms = now_ms();
+    let seed_hint = scenarios.first().map(|scenario| scenario.seed).unwrap_or(0);
+    let match_id = cli
+        .match_id
+        .clone()
+        .unwrap_or_else(|| default_match_id(seed_hint, run_started_at_ms));
     let mut has_anomaly = false;
+    let mut scenario_results = Vec::new();
+    let mut reason_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut total_duration_ms = 0u64;
+    let mut total_anomalies = 0usize;
 
     for scenario in scenarios {
-        let result = run_scenario(&scenario);
-        if !result.anomalies.is_empty() {
+        emit_log(
+            "info",
+            "scenario_started",
+            &match_id,
+            Some(&scenario.name),
+            Some(scenario.seed),
+            None,
+            json!({
+                "aiPlayers": scenario.ai_players,
+                "minutes": scenario.minutes,
+                "difficulty": scenario.difficulty,
+            }),
+        );
+        let scenario_run = run_scenario(&scenario);
+
+        for anomaly in &scenario_run.anomaly_records {
+            emit_log(
+                "warn",
+                "anomaly_detected",
+                &match_id,
+                Some(&scenario.name),
+                Some(scenario.seed),
+                Some(anomaly.tick),
+                json!({
+                    "message": anomaly.message,
+                }),
+            );
+        }
+
+        if !scenario_run.result.anomalies.is_empty() {
             has_anomaly = true;
         }
+        total_anomalies += scenario_run.anomaly_records.len();
+        total_duration_ms += scenario_run.result.duration_ms;
+        *reason_counts
+            .entry(game_over_reason_key(scenario_run.result.reason))
+            .or_insert(0) += 1;
+
+        emit_log(
+            "info",
+            "scenario_finished",
+            &match_id,
+            Some(&scenario.name),
+            Some(scenario.seed),
+            Some(scenario_run.finished_tick),
+            json!({
+                "reason": scenario_run.result.reason,
+                "durationMs": scenario_run.result.duration_ms,
+                "maxCapture": scenario_run.result.max_capture,
+                "anomalyCount": scenario_run.anomaly_records.len(),
+            }),
+        );
+
         println!(
             "{}",
-            serde_json::to_string(&result).expect("scenario result should serialize")
+            serde_json::to_string(&scenario_run.result).expect("scenario result should serialize")
         );
+        scenario_results.push(scenario_run.result);
     }
+
+    let run_finished_at_ms = now_ms();
+    let summary = build_run_summary(
+        match_id.clone(),
+        run_started_at_ms,
+        run_finished_at_ms,
+        scenario_results.clone(),
+        reason_counts,
+        total_anomalies,
+        total_duration_ms,
+    );
+
+    let mut summary_out_written: Option<String> = None;
+    if let Some(path) = cli.summary_out.as_ref() {
+        if let Err(error) = write_summary(path, &summary) {
+            emit_log(
+                "error",
+                "summary_write_failed",
+                &match_id,
+                None,
+                None,
+                None,
+                json!({
+                    "path": path.to_string_lossy(),
+                    "error": error.to_string(),
+                }),
+            );
+            std::process::exit(2);
+        }
+        summary_out_written = Some(path.to_string_lossy().to_string());
+    }
+
+    emit_log(
+        "info",
+        "run_finished",
+        &match_id,
+        None,
+        None,
+        None,
+        json!({
+            "scenarioCount": summary.scenario_count,
+            "anomalyCount": summary.anomaly_count,
+            "averageDurationMs": summary.average_duration_ms,
+            "reasonCounts": summary.reason_counts,
+            "summaryOut": summary_out_written,
+        }),
+    );
 
     if has_anomaly {
         std::process::exit(1);
     }
 }
 
-fn run_scenario(scenario: &Scenario) -> ScenarioResultLine {
+fn run_scenario(scenario: &Scenario) -> ScenarioRunResult {
     let mut start_players = Vec::new();
     for idx in 0..scenario.ai_players {
         start_players.push(StartPlayer {
@@ -112,15 +284,33 @@ fn run_scenario(scenario: &Scenario) -> ScenarioResultLine {
     let mut boss_spawned = 0;
     let mut boss_hits = 0;
     let mut anomalies = Vec::new();
+    let mut anomaly_records = Vec::new();
+    let mut anomaly_seen = HashSet::new();
     let mut tick_safety = 0usize;
+    let mut last_tick = 0u64;
 
     while !engine.is_ended() {
         engine.step(TICK_MS);
         let snapshot = engine.build_snapshot(true);
-        validate_snapshot(&snapshot, &mut anomalies);
+        last_tick = snapshot.tick;
+        for message in collect_snapshot_anomalies(&snapshot) {
+            push_anomaly(
+                &mut anomalies,
+                &mut anomaly_records,
+                &mut anomaly_seen,
+                snapshot.tick,
+                message,
+            );
+        }
         tick_safety += 1;
         if tick_safety > 20 * 60 * 15 {
-            anomalies.push("tick safety limit exceeded".to_string());
+            push_anomaly(
+                &mut anomalies,
+                &mut anomaly_records,
+                &mut anomaly_seen,
+                snapshot.tick,
+                "tick safety limit exceeded".to_string(),
+            );
             break;
         }
 
@@ -149,40 +339,52 @@ fn run_scenario(scenario: &Scenario) -> ScenarioResultLine {
 
     let summary = engine.build_summary();
     if crossed_70 && min_capture_after_70 <= 0.2 {
-        anomalies.push(format!(
-            "capture collapse: reached >=70% but dropped to {:.1}%",
-            min_capture_after_70 * 100.0
-        ));
+        push_anomaly(
+            &mut anomalies,
+            &mut anomaly_records,
+            &mut anomaly_seen,
+            last_tick,
+            format!(
+                "capture collapse: reached >=70% but dropped to {:.1}%",
+                min_capture_after_70 * 100.0
+            ),
+        );
     }
 
-    ScenarioResultLine {
-        scenario: scenario.name.clone(),
-        seed: scenario.seed,
-        ai_players: scenario.ai_players,
-        minutes: scenario.minutes,
-        difficulty: scenario.difficulty,
-        reason: summary.reason,
-        max_capture: (max_capture * 1000.0).round() / 10.0,
-        min_capture_after70: (if crossed_70 {
-            min_capture_after_70
-        } else {
-            1.0
-        } * 1000.0)
-            .round()
-            / 10.0,
-        dot_eaten,
-        dot_respawned,
-        downs,
-        rescues,
-        sector_captured,
-        sector_lost,
-        boss_spawned,
-        boss_hits,
-        anomalies,
+    ScenarioRunResult {
+        result: ScenarioResultLine {
+            scenario: scenario.name.clone(),
+            seed: scenario.seed,
+            ai_players: scenario.ai_players,
+            minutes: scenario.minutes,
+            difficulty: scenario.difficulty,
+            reason: summary.reason,
+            duration_ms: summary.duration_ms,
+            max_capture: (max_capture * 1000.0).round() / 10.0,
+            min_capture_after70: (if crossed_70 {
+                min_capture_after_70
+            } else {
+                1.0
+            } * 1000.0)
+                .round()
+                / 10.0,
+            dot_eaten,
+            dot_respawned,
+            downs,
+            rescues,
+            sector_captured,
+            sector_lost,
+            boss_spawned,
+            boss_hits,
+            anomalies,
+        },
+        anomaly_records,
+        finished_tick: last_tick,
     }
 }
 
-fn validate_snapshot(snapshot: &Snapshot, anomalies: &mut Vec<String>) {
+fn collect_snapshot_anomalies(snapshot: &Snapshot) -> Vec<String> {
+    let mut anomalies = Vec::new();
     if !snapshot.capture_ratio.is_finite()
         || snapshot.capture_ratio < 0.0
         || snapshot.capture_ratio > 1.0
@@ -213,6 +415,7 @@ fn validate_snapshot(snapshot: &Snapshot, anomalies: &mut Vec<String>) {
     if snapshot.sectors.is_empty() {
         anomalies.push("invalid sector configuration".to_string());
     }
+    anomalies
 }
 
 fn resolve_scenarios(cli: &Cli) -> Vec<Scenario> {
@@ -262,4 +465,201 @@ fn clamp_i32(value: i32, min: i32, max: i32) -> i32 {
 
 fn normalize_seed(seed: u64) -> u32 {
     seed as u32
+}
+
+fn push_anomaly(
+    anomalies: &mut Vec<String>,
+    anomaly_records: &mut Vec<AnomalyRecord>,
+    anomaly_seen: &mut HashSet<String>,
+    tick: u64,
+    message: String,
+) {
+    anomaly_records.push(AnomalyRecord {
+        tick,
+        message: message.clone(),
+    });
+    if anomaly_seen.insert(message.clone()) {
+        anomalies.push(message);
+    }
+}
+
+fn default_match_id(seed: u32, timestamp_ms: u64) -> String {
+    format!("sim-{seed}-{timestamp_ms}")
+}
+
+fn build_run_summary(
+    match_id: String,
+    started_at_ms: u64,
+    finished_at_ms: u64,
+    scenarios: Vec<ScenarioResultLine>,
+    reason_counts: BTreeMap<String, usize>,
+    anomaly_count: usize,
+    total_duration_ms: u64,
+) -> RunSummary {
+    let scenario_count = scenarios.len();
+    let average_duration_ms = if scenario_count == 0 {
+        0
+    } else {
+        total_duration_ms / scenario_count as u64
+    };
+    RunSummary {
+        match_id,
+        started_at_ms,
+        finished_at_ms,
+        scenario_count,
+        anomaly_count,
+        average_duration_ms,
+        reason_counts,
+        scenarios,
+    }
+}
+
+fn emit_log(
+    level: &str,
+    event: &str,
+    match_id: &str,
+    scenario: Option<&str>,
+    seed: Option<u32>,
+    tick: Option<u64>,
+    details: Value,
+) {
+    let log_line = StructuredLogLine {
+        timestamp_ms: now_ms(),
+        level: level.to_string(),
+        event: event.to_string(),
+        match_id: match_id.to_string(),
+        scenario: scenario.map(|value| value.to_string()),
+        seed,
+        tick,
+        details,
+    };
+    eprintln!(
+        "{}",
+        serde_json::to_string(&log_line).expect("structured log should serialize")
+    );
+}
+
+fn game_over_reason_key(reason: GameOverReason) -> String {
+    match reason {
+        GameOverReason::Victory => "victory",
+        GameOverReason::Timeout => "timeout",
+        GameOverReason::AllDown => "all_down",
+        GameOverReason::Collapse => "collapse",
+    }
+    .to_string()
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn write_summary(path: &Path, summary: &RunSummary) -> io::Result<()> {
+    let summary_text = serde_json::to_string_pretty(summary).expect("run summary should serialize");
+    std::fs::write(path, summary_text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn make_scenario_result(reason: GameOverReason, duration_ms: u64) -> ScenarioResultLine {
+        ScenarioResultLine {
+            scenario: "test".to_string(),
+            seed: 42,
+            ai_players: 3,
+            minutes: 1,
+            difficulty: Difficulty::Normal,
+            reason,
+            duration_ms,
+            max_capture: 0.0,
+            min_capture_after70: 100.0,
+            dot_eaten: 0,
+            dot_respawned: 0,
+            downs: 0,
+            rescues: 0,
+            sector_captured: 0,
+            sector_lost: 0,
+            boss_spawned: 0,
+            boss_hits: 0,
+            anomalies: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn default_match_id_contains_seed_and_timestamp() {
+        assert_eq!(default_match_id(42, 123456789), "sim-42-123456789");
+    }
+
+    #[test]
+    fn build_run_summary_calculates_average_duration() {
+        let summary = build_run_summary(
+            "sim-42-1".to_string(),
+            1,
+            2,
+            vec![
+                make_scenario_result(GameOverReason::Timeout, 60_000),
+                make_scenario_result(GameOverReason::Victory, 90_000),
+            ],
+            BTreeMap::from([
+                ("timeout".to_string(), 1usize),
+                ("victory".to_string(), 1usize),
+            ]),
+            1,
+            150_000,
+        );
+        assert_eq!(summary.average_duration_ms, 75_000);
+        assert_eq!(summary.scenario_count, 2);
+    }
+
+    #[test]
+    fn write_summary_returns_error_when_parent_does_not_exist() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let target = std::env::temp_dir()
+            .join(format!("mmo-packman-missing-{now}"))
+            .join("summary.json");
+        let summary = build_run_summary(
+            "sim-1-1".to_string(),
+            1,
+            2,
+            vec![make_scenario_result(GameOverReason::Timeout, 60_000)],
+            BTreeMap::from([("timeout".to_string(), 1usize)]),
+            0,
+            60_000,
+        );
+        let result = write_summary(&target, &summary);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn push_anomaly_keeps_records_and_deduplicates_summary_messages() {
+        let mut anomalies = Vec::new();
+        let mut records = Vec::new();
+        let mut seen = HashSet::new();
+        push_anomaly(
+            &mut anomalies,
+            &mut records,
+            &mut seen,
+            10,
+            "same anomaly".to_string(),
+        );
+        push_anomaly(
+            &mut anomalies,
+            &mut records,
+            &mut seen,
+            11,
+            "same anomaly".to_string(),
+        );
+
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].tick, 10);
+        assert_eq!(records[1].tick, 11);
+    }
 }


### PR DESCRIPTION
## Summary
- add `docs/dev/ops-structured-logging/{requirements,design}.md`
- enhance Rust `simulate` with structured JSONL observability logs on stderr (`scenario_started`, `anomaly_detected`, `scenario_finished`, `run_finished`, `summary_write_failed`)
- add `--match-id` and `--summary-out` CLI options and include `durationMs` in scenario results
- write aggregate machine-readable run summary JSON (`scenarioCount`, `anomalyCount`, `averageDurationMs`, `reasonCounts`, `scenarios`)
- update `docs/operation_notes.md` with local / Cloud Run-oriented monitoring procedure

## Quality
- ran `my-review` twice with the same base message + supplement
- addressed review findings:
  - avoid false success log by writing summary before `run_finished`
  - emit structured error on summary write failure and exit with code 2
  - align auto `matchId` format with design (`sim-<seed>-<timestamp_ms>`)
  - count anomaly events (including repeats) while keeping unique anomaly message list
  - use actual finished tick instead of duration-derived tick
  - add unit tests for helper behavior and summary write failure

## Verification
- `npm run check`
- `npm run build`
- `npm run test`
- `cargo fmt --manifest-path rust/server/Cargo.toml --all --check`
- `cargo clippy --manifest-path rust/server/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
- `cargo run --quiet --manifest-path rust/server/Cargo.toml --bin simulate -- --single --ai 3 --minutes 1 --difficulty normal --seed 42 --match-id ops-check --summary-out /tmp/mmo-packman-summary.json`
- `cargo run --quiet --manifest-path rust/server/Cargo.toml --bin simulate -- --single --ai 2 --minutes 1 --seed 42 --match-id fail-check --summary-out /tmp/does-not-exist-dir/summary.json` (expect exit 2)

Refs #38
