### PR TITLE
[Balance] 少人数ボス遭遇/撃破導線の改善

### DIFF
--- a/docs/ai_test_play.md
+++ b/docs/ai_test_play.md
@@ -42,6 +42,7 @@ JSON 1行ごとに1シナリオ結果を出す。
 - `minCaptureAfter70`: 制覇率70%到達後の最低制覇率
 - `downs`, `rescues`: 被弾と立て直し傾向
 - `sectorCaptured`, `sectorLost`: 制圧と劣化の攻防
+- `bossSpawned`, `bossHits`: ボス遭遇数とボス被弾数
 - `anomalies`: 異常検知（空配列が正常）
 
 ## 目安
@@ -49,3 +50,31 @@ JSON 1行ごとに1シナリオ結果を出す。
 - `anomalies` が空であること
 - 同条件で複数回回して、毎回即全滅しないこと
 - `AI x5` で `maxCapture` がある程度上がること
+
+## 12.3 向け少人数ボス導線観測
+
+代表シナリオ:
+
+- `AI x2 / casual / 10分 / seed 1001-1010`
+- `AI x5 / casual / 10分 / seed 4001-4005`
+
+観測指標:
+
+- `bossSpawnedTotal`: 代表seed群で 1 以上（遭遇導線が成立している）
+- `bossHitsTotal`: 代表seed群で 1 以上（撃破導線の評価が可能）
+
+集計例:
+
+```bash
+for seed in $(seq 1001 1010); do
+  npm run -s simulate -- --single --ai 2 --minutes 10 --difficulty casual --seed "$seed"
+done
+for seed in $(seq 4001 4005); do
+  npm run -s simulate -- --single --ai 5 --minutes 10 --difficulty casual --seed "$seed"
+done
+```
+
+最新計測（2026-02-07, issue #44 対応後）:
+
+- `AI x2`: `bossSpawnedTotal=19`, `bossHitsTotal=13`
+- `AI x5`: `bossSpawnedTotal=13`, `bossHitsTotal=20`

--- a/docs/dev/balance-small-party-boss-path/design.md
+++ b/docs/dev/balance-small-party-boss-path/design.md
@@ -1,0 +1,15 @@
+# Design: balance-small-party-boss-path
+
+## Approach
+1. 少人数時に限ってボス出現開始条件を前倒しする（大人数の既存条件は維持）。
+2. 少人数時のボス耐久を調整し、AIの覚醒追跡でヒットが発生しやすい導線を作る。
+3. 実装はゴーストタイプ選択とボスHP決定に局所化し、他システムへの影響を最小化する。
+4. ユニットテストで「少人数時のボス出現」「少人数時ボス耐久」の回帰を固定する。
+
+## Validation
+- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
+- `cargo clippy --manifest-path rust/server/Cargo.toml --all-targets -- -D warnings`
+- `npm run check`
+- `npm run build`
+- `npm run test`
+- `AI x2/x5 / casual / 10分` の代表seedで `bossSpawned` / `bossHits` を集計確認

--- a/docs/dev/balance-small-party-boss-path/requirements.md
+++ b/docs/dev/balance-small-party-boss-path/requirements.md
@@ -1,0 +1,14 @@
+# Requirements: balance-small-party-boss-path
+
+## Goal
+Issue #44 の完了条件に合わせ、少人数シナリオでもボス遭遇〜撃破の検証データを取得できるようにする。
+
+## Functional Requirements
+1. 少人数（AI x2 / AI x5）でボス遭遇が観測できるパラメータを導入すること。
+2. 覚醒ストック3回前提でボスへのヒット（`bossHits`）が発生すること。
+3. 代表seed群で `bossSpawned` / `bossHits` を取得し、検証可能な状態にすること。
+4. 12.3 判定に使うボス関連メトリクスを `docs/ai_test_play.md` に追記すること。
+
+## Non-Functional Requirements
+- 既存の終盤圧（大人数向け）を極端に崩さないこと。
+- Rust/TypeScript の lint/build/test を通すこと。

--- a/rust/server/src/engine/spawn_system.rs
+++ b/rust/server/src/engine/spawn_system.rs
@@ -1,6 +1,16 @@
 use super::*;
 
 impl GameEngine {
+    fn boss_hp_for_player_count(player_count: usize) -> i32 {
+        if player_count <= 2 {
+            1
+        } else if player_count <= 5 {
+            2
+        } else {
+            3
+        }
+    }
+
     pub(super) fn spawn_initial_ghosts(&mut self) {
         let count = get_initial_ghost_count(self.player_count)
             .min(self.max_ghosts)
@@ -14,9 +24,13 @@ impl GameEngine {
         let Some(spawn) = self.pick_ghost_spawn_position(None) else {
             return;
         };
-        let ghost_type = pick_ghost_type(capture_ratio, &mut self.rng);
+        let ghost_type = pick_ghost_type(capture_ratio, self.player_count, &mut self.rng);
         let id = self.make_id("ghost");
-        let hp = if ghost_type == GhostType::Boss { 3 } else { 1 };
+        let hp = if ghost_type == GhostType::Boss {
+            Self::boss_hp_for_player_count(self.player_count)
+        } else {
+            1
+        };
         self.ghosts.push(GhostInternal {
             view: GhostView {
                 id: id.clone(),
@@ -46,13 +60,23 @@ impl GameEngine {
                 y: self.ghosts[ghost_idx].view.y,
             });
         let capture_ratio = self.capture_ratio();
-        let ghost_type = pick_ghost_type(capture_ratio, &mut self.rng);
+        let ghost_type = pick_ghost_type(capture_ratio, self.player_count, &mut self.rng);
         self.ghosts[ghost_idx].view.x = spawn.x;
         self.ghosts[ghost_idx].view.y = spawn.y;
         self.ghosts[ghost_idx].view.ghost_type = ghost_type;
         self.ghosts[ghost_idx].view.dir = random_direction(&mut self.rng);
-        self.ghosts[ghost_idx].view.hp = if ghost_type == GhostType::Boss { 3 } else { 1 };
+        self.ghosts[ghost_idx].view.hp = if ghost_type == GhostType::Boss {
+            Self::boss_hp_for_player_count(self.player_count)
+        } else {
+            1
+        };
         self.ghosts[ghost_idx].view.stunned_until = 0;
+
+        if ghost_type == GhostType::Boss {
+            self.events.push(RuntimeEvent::BossSpawned {
+                ghost_id: self.ghosts[ghost_idx].view.id.clone(),
+            });
+        }
     }
 
     pub(super) fn is_cell_occupied_by_other_ghost(
@@ -126,5 +150,122 @@ impl GameEngine {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GameEngine;
+    use crate::engine::GameEngineOptions;
+    use crate::types::{Difficulty, RuntimeEvent, StartPlayer};
+
+    fn make_players(count: usize) -> Vec<StartPlayer> {
+        (0..count)
+            .map(|idx| StartPlayer {
+                id: format!("p{}", idx + 1),
+                name: format!("P{}", idx + 1),
+                reconnect_token: format!("token_{}", idx + 1),
+                connected: false,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn boss_hp_is_reduced_for_small_party() {
+        assert_eq!(GameEngine::boss_hp_for_player_count(2), 1);
+        assert_eq!(GameEngine::boss_hp_for_player_count(5), 2);
+        assert_eq!(GameEngine::boss_hp_for_player_count(6), 3);
+    }
+
+    #[test]
+    fn respawning_as_boss_emits_boss_spawned_event() {
+        let mut engine = GameEngine::new(
+            make_players(2),
+            Difficulty::Normal,
+            7_777,
+            GameEngineOptions {
+                time_limit_ms_override: Some(60_000),
+            },
+        );
+        assert!(!engine.ghosts.is_empty());
+
+        for sector in &mut engine.world.sectors {
+            sector.view.captured = false;
+        }
+        if let Some(first_sector) = engine.world.sectors.first_mut() {
+            first_sector.view.captured = true;
+        }
+
+        let mut saw_boss_respawn = false;
+        for _ in 0..200 {
+            engine.events.clear();
+            engine.respawn_ghost(0);
+            if engine.ghosts[0].view.ghost_type != crate::types::GhostType::Boss {
+                continue;
+            }
+            saw_boss_respawn = true;
+            assert_eq!(
+                engine.ghosts[0].view.hp,
+                GameEngine::boss_hp_for_player_count(2)
+            );
+            let has_event = engine.events.iter().any(|event| {
+                matches!(
+                    event,
+                    RuntimeEvent::BossSpawned { ghost_id } if ghost_id == &engine.ghosts[0].view.id
+                )
+            });
+            assert!(has_event);
+            break;
+        }
+        assert!(saw_boss_respawn);
+    }
+
+    #[test]
+    fn spawn_ghost_applies_scaled_boss_hp() {
+        let mut duo = GameEngine::new(
+            make_players(2),
+            Difficulty::Normal,
+            7_778,
+            GameEngineOptions {
+                time_limit_ms_override: Some(60_000),
+            },
+        );
+        let mut squad = GameEngine::new(
+            make_players(6),
+            Difficulty::Normal,
+            7_779,
+            GameEngineOptions {
+                time_limit_ms_override: Some(60_000),
+            },
+        );
+
+        let mut duo_hp = None;
+        for _ in 0..400 {
+            duo.ghosts.clear();
+            duo.spawn_ghost(duo.started_at_ms, 0.25);
+            let Some(ghost) = duo.ghosts.first() else {
+                continue;
+            };
+            if ghost.view.ghost_type == crate::types::GhostType::Boss {
+                duo_hp = Some(ghost.view.hp);
+                break;
+            }
+        }
+
+        let mut squad_hp = None;
+        for _ in 0..400 {
+            squad.ghosts.clear();
+            squad.spawn_ghost(squad.started_at_ms, 0.95);
+            let Some(ghost) = squad.ghosts.first() else {
+                continue;
+            };
+            if ghost.view.ghost_type == crate::types::GhostType::Boss {
+                squad_hp = Some(ghost.view.hp);
+                break;
+            }
+        }
+
+        assert_eq!(duo_hp, Some(GameEngine::boss_hp_for_player_count(2)));
+        assert_eq!(squad_hp, Some(GameEngine::boss_hp_for_player_count(6)));
     }
 }

--- a/rust/server/src/engine/utils.rs
+++ b/rust/server/src/engine/utils.rs
@@ -50,52 +50,118 @@ pub(super) fn random_direction(rng: &mut Rng) -> Direction {
     }
 }
 
-pub(super) fn pick_ghost_type(capture_ratio: f32, rng: &mut Rng) -> GhostType {
+pub(super) fn pick_ghost_type(capture_ratio: f32, player_count: usize, rng: &mut Rng) -> GhostType {
     let roll = rng.next_f32();
-    if capture_ratio < 0.3 {
+    let mut ghost_type = if capture_ratio < 0.3 {
         if roll < 0.75 {
-            return GhostType::Random;
+            GhostType::Random
+        } else {
+            GhostType::Chaser
         }
-        return GhostType::Chaser;
-    }
-    if capture_ratio < 0.6 {
+    } else if capture_ratio < 0.6 {
         if roll < 0.3 {
-            return GhostType::Random;
+            GhostType::Random
+        } else if roll < 0.55 {
+            GhostType::Chaser
+        } else if roll < 0.8 {
+            GhostType::Patrol
+        } else {
+            GhostType::Pincer
         }
-        if roll < 0.55 {
-            return GhostType::Chaser;
-        }
-        if roll < 0.8 {
-            return GhostType::Patrol;
-        }
-        return GhostType::Pincer;
-    }
-    if capture_ratio < 0.9 {
+    } else if capture_ratio < 0.9 {
         if roll < 0.2 {
-            return GhostType::Random;
+            GhostType::Random
+        } else if roll < 0.4 {
+            GhostType::Chaser
+        } else if roll < 0.6 {
+            GhostType::Patrol
+        } else if roll < 0.8 {
+            GhostType::Pincer
+        } else {
+            GhostType::Invader
         }
-        if roll < 0.4 {
-            return GhostType::Chaser;
+    } else if roll < 0.1 {
+        GhostType::Random
+    } else if roll < 0.25 {
+        GhostType::Chaser
+    } else if roll < 0.5 {
+        GhostType::Pincer
+    } else if roll < 0.8 {
+        GhostType::Invader
+    } else {
+        GhostType::Boss
+    };
+
+    if player_count <= 5 && capture_ratio < 0.9 && ghost_type != GhostType::Boss {
+        let bonus_boss_chance = if player_count <= 2 {
+            if capture_ratio >= 0.25 {
+                0.12
+            } else {
+                0.02
+            }
+        } else if capture_ratio >= 0.6 {
+            0.24
+        } else if capture_ratio >= 0.45 {
+            0.14
+        } else if capture_ratio >= 0.25 {
+            0.07
+        } else {
+            0.0
+        };
+        let bonus_roll = ((roll * 9_973.0) + 0.37).fract();
+        if bonus_boss_chance > 0.0 && bonus_roll < bonus_boss_chance {
+            ghost_type = GhostType::Boss;
         }
-        if roll < 0.6 {
-            return GhostType::Patrol;
+    }
+    ghost_type
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_party_can_roll_boss_before_ninety_percent_capture() {
+        let mut saw_boss = false;
+        for seed in 1..=2_000u32 {
+            let mut rng = Rng::new(seed);
+            if pick_ghost_type(0.45, 5, &mut rng) == GhostType::Boss {
+                saw_boss = true;
+                break;
+            }
         }
-        if roll < 0.8 {
-            return GhostType::Pincer;
+        assert!(saw_boss);
+    }
+
+    #[test]
+    fn duo_can_roll_boss_even_at_low_capture() {
+        let mut saw_boss = false;
+        for seed in 1..=2_000u32 {
+            let mut rng = Rng::new(seed);
+            if pick_ghost_type(0.0, 2, &mut rng) == GhostType::Boss {
+                saw_boss = true;
+                break;
+            }
         }
-        return GhostType::Invader;
+        assert!(saw_boss);
     }
-    if roll < 0.1 {
-        return GhostType::Random;
+
+    #[test]
+    fn large_party_never_rolls_boss_before_ninety_percent_capture() {
+        for seed in 1..=2_000u32 {
+            let mut rng = Rng::new(seed);
+            assert_ne!(pick_ghost_type(0.85, 80, &mut rng), GhostType::Boss);
+        }
     }
-    if roll < 0.25 {
-        return GhostType::Chaser;
+
+    #[test]
+    fn small_party_does_not_get_extra_boss_bonus_after_ninety_percent_capture() {
+        for seed in 1..=2_000u32 {
+            let mut small_rng = Rng::new(seed);
+            let mut large_rng = Rng::new(seed);
+            let small = pick_ghost_type(0.95, 5, &mut small_rng);
+            let large = pick_ghost_type(0.95, 80, &mut large_rng);
+            assert_eq!(small as u8, large as u8);
+        }
     }
-    if roll < 0.5 {
-        return GhostType::Pincer;
-    }
-    if roll < 0.8 {
-        return GhostType::Invader;
-    }
-    GhostType::Boss
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -237,7 +237,7 @@ function applyEvent(event: RuntimeEvent): void {
   } else if (event.type === 'boss_spawned') {
     pushLog('ボスゴースト出現');
   } else if (event.type === 'boss_hit') {
-    pushLog(`ボスにヒット (${event.hp}/3)`);
+    pushLog(`ボスにヒット (残りHP: ${event.hp})`);
   } else if (event.type === 'toast') {
     pushLog(event.message);
   }


### PR DESCRIPTION
## Summary
- Issue #44 向けに、少人数シナリオでボス遭遇/被弾データが取れるようボス導線を追加
- `bossSpawned` 指標の定義ズレ（respawn時未計上）を修正
- 12.3 判定向けメトリクスを `docs/ai_test_play.md` に追記

## Docs
- `docs/dev/balance-small-party-boss-path/requirements.md`
- `docs/dev/balance-small-party-boss-path/design.md`
- `docs/ai_test_play.md`

## Main Changes
- `rust/server/src/engine/utils.rs`
  - `pick_ghost_type` に `player_count` を追加
  - 少人数向けのボス注入（`capture_ratio < 0.9` に限定）
  - ボス注入回帰テストを追加
- `rust/server/src/engine/spawn_system.rs`
  - 少人数ボスHP（2人以下:1 / 5人以下:2 / 6人以上:3）
  - `respawn_ghost` でボス化した場合も `BossSpawned` を発火
  - スポーン経路/リスポーン経路のHP適用テストを追加
- `src/client/main.ts`
  - `boss_hit` ログ表示の固定 `/3` を廃止し、残りHP表示へ変更

## Validation
- `cargo fmt --manifest-path rust/server/Cargo.toml --all`
- `cargo clippy --manifest-path rust/server/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
- `npm run check`
- `npm run build`
- `npm run test`

## Simulation Metrics (casual, 10m)
- AI x2 / seed 1001-1010
  - `bossSpawnedTotal: 0 -> 19`
  - `bossHitsTotal: 0 -> 13`
  - `allDownRate: 20%`
- AI x5 / seed 4001-4005
  - `bossSpawnedTotal: 0 -> 13`
  - `bossHitsTotal: 0 -> 20`

## Review Notes
- `my-review` 1回目指摘（指標定義ズレ、終盤ボス率、テスト不足）を反映済み
- `my-review` 2回目指摘（UI表示整合、乱数消費、spawn経路テスト不足）を反映済み

Closes #44
