### PR TITLE
[Balance] 5人カジュアルのクリア成立性を改善

### DIFF
--- a/docs/dev/balance-five-player-casual-clearability/design.md
+++ b/docs/dev/balance-five-player-casual-clearability/design.md
@@ -1,0 +1,15 @@
+# Design: balance-five-player-casual-clearability
+
+## Approach
+1. 5人カジュアル限定で終盤支援係数を導入する。移動速度補正は `capture_ratio >= 0.4` で有効化し、終盤のみ押し切りやすくする。
+2. 5人カジュアル限定で敵圧（ゴースト人口や追跡圧）を緩和する。ゴースト目標数は制覇率に応じて `4 -> 5` へ段階増加させる。
+3. 調整は `GameEngine` 内の5人カジュアル条件分岐へ閉じ、他帯域への影響を最小化する。
+4. ユニットテストで適用境界（人数・難易度）と挙動（速度補正の有効化条件、掌握/喪失しきい値、ゴースト目標数）を固定する。
+
+## Validation
+- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
+- `cargo clippy --manifest-path rust/server/Cargo.toml --all-targets -- -D warnings`
+- `npm run check`
+- `npm run build`
+- `npm run test`
+- `AI x5 / casual / 10分 / seed 4001-4005` で `victory >= 1件`

--- a/docs/dev/balance-five-player-casual-clearability/requirements.md
+++ b/docs/dev/balance-five-player-casual-clearability/requirements.md
@@ -1,0 +1,13 @@
+# Requirements: balance-five-player-casual-clearability
+
+## Goal
+Issue #42 の完了条件に合わせ、5人カジュアルの代表seed群でクリア到達（victory）を観測できるようにする。
+
+## Functional Requirements
+1. `AI x5 / casual / 10分 / seed 4001-4005` の代表seed群で、少なくとも1件以上 `reason == victory` を観測できること。
+2. 5人カジュアル向けに終盤進行（維持コスト・敵圧・救助導線）を改善すること。
+3. 調整根拠と代表seed群の結果を `docs/operation_notes.md` に記録すること。
+
+## Non-Functional Requirements
+- 2人カジュアル（issue #45）など既存の少人数調整を破壊しないこと。
+- lint/build/test を通すこと。

--- a/docs/operation_notes.md
+++ b/docs/operation_notes.md
@@ -87,6 +87,39 @@ done
 
 - `AI x80`: `maxCapture=25.0, 13.9`（`avgMaxCapture=19.45%`）
 
+## 5人カジュアルのクリア成立性観測（Issue #42）
+
+対象シナリオ:
+
+- `AI x5 / casual / 10分 / seed 4001-4005`
+
+観測指標:
+
+- `victoryCount`: `reason == victory` の件数（目標: 1件以上）
+- `avgMaxCapture`: 代表seed群の平均最大制覇率
+
+仕様メモ:
+
+- issue #42 では 5人カジュアルのみ、終盤支援の係数（掌握・喪失しきい値、維持コスト、敵圧）を調整する。
+
+計測コマンド:
+
+```bash
+for seed in $(seq 4001 4005); do
+  npm run -s simulate -- --single --ai 5 --minutes 10 --difficulty casual --seed "$seed"
+done
+```
+
+最新計測（2026-02-07, issue #42 対応後）:
+
+- `victoryCount=3/5`（seed `4001`, `4002`, `4005`）
+- `avgMaxCapture=85.0%`
+
+参考ベースライン（調整前）:
+
+- `victoryCount=0/5`
+- `avgMaxCapture=25.0%`
+
 ## 既知のMVP制約
 
 - 永続化なし


### PR DESCRIPTION
## 概要
- issue #42 向けに、5人カジュアルでクリア到達が発生するように終盤進行を改善しました。
- 5人カジュアル限定で、掌握/喪失しきい値・維持コスト・敵圧・終盤速度補正を調整。
- 4人以下/6人以上、または casual 以外へは適用されないよう境界を固定しました。

## 変更ファイル
- `docs/dev/balance-five-player-casual-clearability/requirements.md`
- `docs/dev/balance-five-player-casual-clearability/design.md`
- `docs/operation_notes.md`
- `rust/server/src/engine/mod.rs`

## 実装ポイント
- 5人casual判定ヘルパーを導入し、適用スコープを限定。
- ゴースト目標数プロファイルを制覇率に応じた段階制（4->5）へ調整。
- 掌握/喪失しきい値を5人casual限定で緩和。
- 速度補正(1.12)は `capture_ratio >= 0.4` の終盤のみ有効化。
- 境界・挙動テストを追加
  - 5casual適用 / 5normal非適用 / 4casual非適用 / 6casual非適用
  - 速度補正の有効化条件
  - ゴースト目標数の制覇率連動
  - 掌握/喪失しきい値の適用範囲

## 検証
- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
- `cargo clippy --manifest-path rust/server/Cargo.toml --all-targets -- -D warnings`
- `npm run check`
- `npm run build`
- `npm run test`

## シミュレーション結果（AI x5 / casual / 10分 / seed 4001-4005）
- `victoryCount=3/5`（seed `4001`, `4002`, `4005`）
- `avgMaxCapture=85.0%`

Refs #42
