### PR TITLE
[Issue #34] 詳細表彰ロジックの追加

### DIFF
--- a/docs/dev/result-detailed-awards/design.md
+++ b/docs/dev/result-detailed-awards/design.md
@@ -1,0 +1,18 @@
+# Design: result-detailed-awards
+
+## Approach
+1. Rust 側 `GameSummary` に `awards` フィールドを追加し、`ScoreEntry` からカテゴリ別最大値を抽出して受賞者を決定する。
+2. 表彰カテゴリは MVP 相当の主要軸として以下を採用する。
+   - `rescue_king`（救助王）: `rescues`
+   - `explorer_king`（探索王）: `dots`
+   - `defense_king`（防衛王）: `captures`
+   - `ghost_hunter`（ゴーストハンター）: `ghosts`
+3. すべて 0 件のカテゴリは表彰対象外として `awards` から除外し、ノイズ表示を避ける。
+4. クライアントでは `summary.awards` をレンダリングし、同率受賞時は複数名を併記する。
+5. サーバープロトコル文書に `game_over.summary.awards` の JSON 例を追記する。
+
+## Validation
+- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
+- `npm run check`
+- `npm run build`
+- `npm run test`

--- a/docs/dev/result-detailed-awards/requirements.md
+++ b/docs/dev/result-detailed-awards/requirements.md
@@ -1,0 +1,14 @@
+# Requirements: result-detailed-awards
+
+## Goal
+Issue #34 の完了条件に合わせ、試合サマリから主要行動メトリクスを表彰として可視化し、リザルト体験を向上する。
+
+## Functional Requirements
+1. `game_over.summary` に表彰情報を含め、少なくとも `救助王 / 探索王 / 防衛王` を算出できること。
+2. 表彰は試合中に集計済みメトリクス（`rescues`, `dots`, `captures` など）から決定し、同率受賞に対応すること。
+3. クライアントのリザルト画面に表彰セクションを追加し、受賞カテゴリ・受賞者・値を表示できること。
+4. 表彰データ構造を `docs/server_protocol.md` に追記し、クライアント/サーバー間契約を明文化すること。
+
+## Non-Functional Requirements
+- 既存ランキング表示と互換性を維持し、既存メッセージ型を破壊しないこと。
+- lint/build/test を pass すること。

--- a/docs/server_protocol.md
+++ b/docs/server_protocol.md
@@ -45,6 +45,7 @@
 - `game_over`
   - 勝敗理由
   - ランキング
+  - 表彰（`summary.awards`）
   - タイムライン
 - `error`
   - エラーメッセージ
@@ -61,3 +62,31 @@
 
 - 現在はMVPのためメッセージ署名・暗号化は未実装
 - 本番化時は認証とレート制限を追加する
+
+## `game_over.summary.awards` の形式
+
+```json
+{
+  "awards": [
+    {
+      "id": "rescue_king",
+      "title": "救助王",
+      "metricLabel": "救助数",
+      "value": 7,
+      "winners": [
+        {
+          "playerId": "p1",
+          "name": "P1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `id`: `rescue_king | explorer_king | defense_king | ghost_hunter`
+- `metricLabel`: UI 表示向けの指標名
+- `value`: 指標の受賞値（同率受賞時は共通）
+- `winners`: 同率を含む受賞者一覧
+- `awards` は常に配列として送信される（該当なしの場合は `[]`）
+- すべて 0 件のカテゴリは送信対象外（`awards` から除外）

--- a/rust/server/src/types.rs
+++ b/rust/server/src/types.rs
@@ -306,6 +306,32 @@ pub struct ScoreEntry {
 }
 
 #[derive(Clone, Debug, Serialize)]
+pub struct AwardWinner {
+    #[serde(rename = "playerId")]
+    pub player_id: String,
+    pub name: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AwardId {
+    RescueKing,
+    ExplorerKing,
+    DefenseKing,
+    GhostHunter,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AwardEntry {
+    pub id: AwardId,
+    pub title: String,
+    #[serde(rename = "metricLabel")]
+    pub metric_label: String,
+    pub value: i32,
+    pub winners: Vec<AwardWinner>,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct GameSummary {
     pub reason: GameOverReason,
     #[serde(rename = "durationMs")]
@@ -314,6 +340,7 @@ pub struct GameSummary {
     pub capture_ratio: f32,
     pub timeline: Vec<TimelineEvent>,
     pub ranking: Vec<ScoreEntry>,
+    pub awards: Vec<AwardEntry>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,4 +1,5 @@
 import type {
+  AwardEntry,
   ClientMessage,
   Difficulty,
   FruitView,
@@ -192,7 +193,7 @@ function handleServerMessage(message: ServerMessage): void {
   }
 
   if (message.type === 'game_over') {
-    summary = message.summary;
+    summary = normalizeSummary(message.summary);
     showResult();
     updateStatusPanels();
     return;
@@ -361,6 +362,7 @@ function showResult(): void {
   }
 
   result.classList.remove('hidden');
+  const awards = renderAwards(summary.awards);
   const ranking = summary.ranking
     .slice(0, 8)
     .map((entry, index) => {
@@ -372,6 +374,8 @@ function showResult(): void {
     <div class="panel">
       <h2>ゲーム終了: ${summary.reason}</h2>
       <p>制覇率: ${(summary.captureRatio * 100).toFixed(1)}%</p>
+      <h3>表彰</h3>
+      ${awards}
       <h3>ランキング</h3>
       <ol>${ranking}</ol>
       <h3>タイムライン</h3>
@@ -384,6 +388,30 @@ function showResult(): void {
   close?.addEventListener('click', () => {
     result.classList.add('hidden');
   });
+}
+
+function normalizeSummary(raw: GameSummary): GameSummary {
+  return {
+    ...raw,
+    awards: raw.awards ?? [],
+  };
+}
+
+function renderAwards(awards: AwardEntry[]): string {
+  if (awards.length === 0) {
+    return '<p class="muted">該当する表彰はありません。</p>';
+  }
+
+  return `
+    <ul>
+      ${awards
+        .map((award) => {
+          const winnerNames = award.winners.map((winner) => escapeHtml(winner.name)).join(', ');
+          return `<li><strong>${escapeHtml(award.title)}</strong> (${escapeHtml(award.metricLabel)}: ${award.value}) - ${winnerNames}</li>`;
+        })
+        .join('')}
+    </ul>
+  `;
 }
 
 function wireKeyboard(): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -147,12 +147,26 @@ export interface ScoreEntry {
   captures: number;
 }
 
+export interface AwardWinner {
+  playerId: string;
+  name: string;
+}
+
+export interface AwardEntry {
+  id: 'rescue_king' | 'explorer_king' | 'defense_king' | 'ghost_hunter';
+  title: string;
+  metricLabel: string;
+  value: number;
+  winners: AwardWinner[];
+}
+
 export interface GameSummary {
   reason: GameOverReason;
   durationMs: number;
   captureRatio: number;
   timeline: TimelineEvent[];
   ranking: ScoreEntry[];
+  awards: AwardEntry[];
 }
 
 export type ClientMessage =


### PR DESCRIPTION
## 概要
Issue #34 の対応として、リザルト画面の詳細表彰ロジックを追加しました。

## 変更内容
- `docs/dev/result-detailed-awards/{requirements,design}.md` を新規作成
- Rust `GameSummary` に `awards` を追加し、以下カテゴリを算出
  - `rescue_king`（救助王）
  - `explorer_king`（探索王）
  - `defense_king`（防衛王）
  - `ghost_hunter`（ゴーストハンター）
- 同率受賞に対応し、0件カテゴリは `awards` から除外
- `award.id` を Rust 側 enum 化して契約の typo をコンパイル時に検知
- クライアント結果画面に表彰セクションを追加
- 後方互換のため、受信時に `summary.awards` 欠落を `[]` に正規化
- `docs/server_protocol.md` に `game_over.summary.awards` 仕様を追記

## テスト
- `cargo test --manifest-path rust/server/Cargo.toml --all-targets`
- `npm run check`
- `npm run build`
- `npm run test`

## レビュー
- `my-review` を 2 回実施し、指摘事項を反映済み

Closes #34
