### PR TITLE
refactor: modularize client replay model utilities

### DIFF
--- a/docs/dev/client-main-modularize/design.md
+++ b/docs/dev/client-main-modularize/design.md
@@ -1,0 +1,11 @@
+# Design: client-main-modularize
+
+## Approach
+1. `src/client/replay_model.ts` を新規追加し、`normalizeSummary` / `normalizeSnapshot` / `cloneWorld` / `cloneSnapshot` を集約する。
+2. `main.ts` と `replay_parser.ts` は上記モジュールを import するだけに変更し、重複実装を削除する。
+3. 既存の `replay_parser.selftest` と全体 test/build/check で回帰確認する。
+
+## Validation
+- `npm run check`
+- `npm run build`
+- `npm run test`

--- a/docs/dev/client-main-modularize/requirements.md
+++ b/docs/dev/client-main-modularize/requirements.md
@@ -1,0 +1,12 @@
+# Requirements: client-main-modularize
+
+## Goal
+Issue #66 の完了条件として、`src/client/main.ts` の責務を分離し、`replay_parser.ts` と重複するロジックを共通化する。
+
+## Functional Requirements
+1. `main.ts` と `replay_parser.ts` に重複する replay 用 clone/normalize ロジックを共通モジュールへ統合すること。
+2. `main.ts` から replay データ変換責務を切り出し、呼び出し側を薄くすること。
+3. 既存の replay import/export と再生挙動を維持すること。
+
+## Non-Functional Requirements
+- `npm run check` / `npm run build` / `npm run test` を pass する。

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -24,6 +24,7 @@ import {
   PLAYER_CAPTURED_SPEED_MULTIPLIER,
 } from '../shared/constants.js';
 import { findReplayFrameIndex, parseReplayLog, type ReplayFrame, type ReplayLog } from './replay_parser.js';
+import { cloneSnapshot, cloneWorld, normalizeSummary, normalizeSnapshot } from './replay_model.js';
 
 const canvas = mustElement<HTMLCanvasElement>('game');
 const hud = mustElement<HTMLElement>('hud');
@@ -661,57 +662,6 @@ function showResult(): void {
     void importReplayFromFile(file);
     importReplayInput.value = '';
   });
-}
-
-function normalizeSummary(raw: GameSummary): GameSummary {
-  return {
-    ...raw,
-    awards: raw.awards ?? [],
-  };
-}
-
-function normalizeSnapshot(raw: Snapshot): Snapshot {
-  return {
-    ...raw,
-    pings: raw.pings ?? [],
-  };
-}
-
-function cloneWorld(raw: WorldInit): WorldInit {
-  return {
-    ...raw,
-    tiles: [...raw.tiles],
-    sectors: raw.sectors.map((sector) => ({ ...sector })),
-    gates: raw.gates.map((gate) => ({
-      ...gate,
-      a: { ...gate.a },
-      b: { ...gate.b },
-      switchA: { ...gate.switchA },
-      switchB: { ...gate.switchB },
-    })),
-    dots: raw.dots.map(([x, y]) => [x, y]),
-    powerPellets: raw.powerPellets.map((pellet) => ({ ...pellet })),
-  };
-}
-
-function cloneSnapshot(raw: Snapshot): Snapshot {
-  return {
-    ...raw,
-    players: raw.players.map((player) => ({ ...player })),
-    ghosts: raw.ghosts.map((ghost) => ({ ...ghost })),
-    fruits: raw.fruits.map((fruit) => ({ ...fruit })),
-    sectors: raw.sectors.map((sector) => ({ ...sector })),
-    gates: raw.gates.map((gate) => ({
-      ...gate,
-      a: { ...gate.a },
-      b: { ...gate.b },
-      switchA: { ...gate.switchA },
-      switchB: { ...gate.switchB },
-    })),
-    pings: raw.pings.map((ping) => ({ ...ping })),
-    events: raw.events.map((event) => ({ ...event })),
-    timeline: raw.timeline.map((item) => ({ ...item })),
-  };
 }
 
 function captureReplayFrame(state: Snapshot): ReplayFrame {

--- a/src/client/replay_model.ts
+++ b/src/client/replay_model.ts
@@ -1,0 +1,52 @@
+import type { GameSummary, Snapshot, WorldInit } from '../shared/types.js';
+
+export function normalizeSummary(raw: GameSummary): GameSummary {
+  return {
+    ...raw,
+    awards: raw.awards ?? [],
+  };
+}
+
+export function normalizeSnapshot(raw: Snapshot): Snapshot {
+  return {
+    ...raw,
+    pings: raw.pings ?? [],
+  };
+}
+
+export function cloneWorld(raw: WorldInit): WorldInit {
+  return {
+    ...raw,
+    tiles: [...raw.tiles],
+    sectors: raw.sectors.map((sector) => ({ ...sector })),
+    gates: raw.gates.map((gate) => ({
+      ...gate,
+      a: { ...gate.a },
+      b: { ...gate.b },
+      switchA: { ...gate.switchA },
+      switchB: { ...gate.switchB },
+    })),
+    dots: raw.dots.map(([x, y]): [number, number] => [x, y]),
+    powerPellets: raw.powerPellets.map((pellet) => ({ ...pellet })),
+  };
+}
+
+export function cloneSnapshot(raw: Snapshot): Snapshot {
+  return {
+    ...raw,
+    players: raw.players.map((player) => ({ ...player })),
+    ghosts: raw.ghosts.map((ghost) => ({ ...ghost })),
+    fruits: raw.fruits.map((fruit) => ({ ...fruit })),
+    sectors: raw.sectors.map((sector) => ({ ...sector })),
+    gates: raw.gates.map((gate) => ({
+      ...gate,
+      a: { ...gate.a },
+      b: { ...gate.b },
+      switchA: { ...gate.switchA },
+      switchB: { ...gate.switchB },
+    })),
+    pings: raw.pings.map((ping) => ({ ...ping })),
+    events: raw.events.map((event) => ({ ...event })),
+    timeline: raw.timeline.map((item) => ({ ...item })),
+  };
+}

--- a/src/client/replay_parser.selftest.ts
+++ b/src/client/replay_parser.selftest.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import type { Snapshot } from '../shared/types.js';
+import type { GameSummary, Snapshot, WorldInit } from '../shared/types.js';
+import { cloneSnapshot, cloneWorld, normalizeSnapshot, normalizeSummary } from './replay_model.js';
 import { findReplayFrameIndex, parseReplayLog } from './replay_parser.js';
 
 function makeSnapshot(tick: number, nowMs: number): Snapshot {
@@ -19,18 +20,50 @@ function makeSnapshot(tick: number, nowMs: number): Snapshot {
   };
 }
 
-function testFindReplayFrameIndex(): void {
-  const offsets = [0, 400, 900, 1600];
-  assert.equal(findReplayFrameIndex(offsets, 0), 0);
-  assert.equal(findReplayFrameIndex(offsets, 399), 0);
-  assert.equal(findReplayFrameIndex(offsets, 401), 1);
-  assert.equal(findReplayFrameIndex(offsets, 999), 2);
-  assert.equal(findReplayFrameIndex(offsets, 9999), 3);
+function makeWorld(): WorldInit {
+  return {
+    width: 4,
+    height: 4,
+    sectorSize: 2,
+    side: 2,
+    tiles: ['....', '....', '....', '....'],
+    sectors: [
+      {
+        id: 1,
+        row: 0,
+        col: 0,
+        x: 0,
+        y: 0,
+        size: 2,
+        type: 'normal',
+        discovered: false,
+        captured: false,
+        dotCount: 2,
+        totalDots: 2,
+      },
+    ],
+    gates: [
+      {
+        id: 'g-1',
+        a: { x: 0, y: 1 },
+        b: { x: 3, y: 1 },
+        switchA: { x: 1, y: 1 },
+        switchB: { x: 2, y: 1 },
+        open: false,
+        permanent: false,
+      },
+    ],
+    dots: [
+      [1, 1],
+      [1, 2],
+    ],
+    powerPellets: [{ key: '2,2', x: 2, y: 2, active: true }],
+  };
 }
 
-function testParseReplayLog(): void {
-  const replay = {
-    format: 'mmo-packman-replay-v1',
+function makeReplay() {
+  return {
+    format: 'mmo-packman-replay-v1' as const,
     recordedAtIso: '2026-02-07T00:00:00.000Z',
     seed: 42,
     config: {
@@ -41,27 +74,12 @@ function testParseReplayLog(): void {
       awakenDurationMs: 5000,
       rescueTimeoutMs: 6000,
       timeLimitMs: 300000,
-      difficulty: 'normal',
+      difficulty: 'normal' as const,
     },
-    world: {
-      width: 4,
-      height: 4,
-      sectorSize: 2,
-      side: 2,
-      tiles: ['....', '....', '....', '....'],
-      sectors: [],
-      gates: [],
-      dots: [
-        [1, 1],
-        [1, 2],
-      ],
-      powerPellets: [
-        { key: '2,2', x: 2, y: 2, active: true },
-      ],
-    },
+    world: makeWorld(),
     startedAtMs: 1000,
     summary: {
-      reason: 'timeout',
+      reason: 'timeout' as const,
       durationMs: 1000,
       captureRatio: 0.3,
       timeline: [],
@@ -76,6 +94,19 @@ function testParseReplayLog(): void {
       },
     ],
   };
+}
+
+function testFindReplayFrameIndex(): void {
+  const offsets = [0, 400, 900, 1600];
+  assert.equal(findReplayFrameIndex(offsets, 0), 0);
+  assert.equal(findReplayFrameIndex(offsets, 399), 0);
+  assert.equal(findReplayFrameIndex(offsets, 401), 1);
+  assert.equal(findReplayFrameIndex(offsets, 999), 2);
+  assert.equal(findReplayFrameIndex(offsets, 9999), 3);
+}
+
+function testParseReplayLog(): void {
+  const replay = makeReplay();
 
   const parsed = parseReplayLog(replay);
   assert.ok(parsed);
@@ -97,10 +128,147 @@ function testRejectLegacyFrameShape(): void {
   assert.equal(parseReplayLog(legacy), null);
 }
 
+function testRejectMalformedSnapshotCollections(): void {
+  const malformed = makeReplay();
+  malformed.frames[0] = {
+    ...malformed.frames[0],
+    snapshot: {
+      ...malformed.frames[0].snapshot,
+      pings: 'oops',
+    } as unknown as Snapshot,
+  };
+  assert.doesNotThrow(() => parseReplayLog(malformed));
+  assert.equal(parseReplayLog(malformed), null);
+}
+
+function testAcceptSnapshotWithoutPings(): void {
+  const replay = makeReplay();
+  const snapshotWithoutPings = { ...replay.frames[0].snapshot } as Record<string, unknown>;
+  delete snapshotWithoutPings.pings;
+  replay.frames[0] = {
+    ...replay.frames[0],
+    snapshot: snapshotWithoutPings as unknown as Snapshot,
+  };
+  const parsed = parseReplayLog(replay);
+  assert.ok(parsed);
+  assert.deepEqual(parsed?.frames[0].snapshot.pings, []);
+}
+
+function testRejectMalformedWorldCollections(): void {
+  const malformed = makeReplay();
+  malformed.world = {
+    ...malformed.world,
+    tiles: 'oops',
+  } as unknown as WorldInit;
+  assert.equal(parseReplayLog(malformed), null);
+}
+
+function testReplayModelUtilities(): void {
+  const world = makeWorld();
+  const worldCloned = cloneWorld(world);
+  world.tiles[0] = '####';
+  world.sectors[0].captured = true;
+  world.gates[0].a.x = 99;
+  world.dots[0][0] = 99;
+  world.powerPellets[0].active = false;
+  assert.equal(worldCloned.tiles[0], '....');
+  assert.equal(worldCloned.sectors[0].captured, false);
+  assert.equal(worldCloned.gates[0].a.x, 0);
+  assert.equal(worldCloned.dots[0][0], 1);
+  assert.equal(worldCloned.powerPellets[0].active, true);
+
+  const snapshot: Snapshot = {
+    ...makeSnapshot(1, 1100),
+    players: [
+      {
+        id: 'p1',
+        name: 'Alice',
+        x: 1,
+        y: 1,
+        dir: 'left',
+        state: 'normal',
+        stocks: 3,
+        gauge: 10,
+        gaugeMax: 100,
+        score: 100,
+        connected: true,
+        ai: false,
+        speedBuffUntil: 0,
+        powerUntil: 0,
+        downSince: null,
+      },
+    ],
+    ghosts: [
+      {
+        id: 'g1',
+        x: 2,
+        y: 2,
+        dir: 'right',
+        type: 'random',
+        hp: 3,
+        stunnedUntil: 0,
+      },
+    ],
+    fruits: [{ id: 'f1', type: 'apple', x: 3, y: 3, spawnedAt: 1000 }],
+    sectors: [...makeWorld().sectors],
+    gates: [...makeWorld().gates],
+    pings: [
+      {
+        id: 'ping-1',
+        ownerId: 'p1',
+        ownerName: 'Alice',
+        x: 1,
+        y: 2,
+        kind: 'focus',
+        createdAtMs: 1000,
+        expiresAtMs: 2000,
+      },
+    ],
+    events: [{ type: 'toast', message: 'hello' }],
+    timeline: [{ atMs: 1000, label: 'tick-1' }],
+  };
+  const snapshotCloned = cloneSnapshot(snapshot);
+  snapshot.players[0].name = 'Bob';
+  snapshot.ghosts[0].x = 9;
+  snapshot.fruits[0].x = 9;
+  snapshot.sectors[0].captured = true;
+  snapshot.gates[0].open = true;
+  snapshot.pings[0].kind = 'danger';
+  snapshot.events[0] = { type: 'toast', message: 'updated' };
+  snapshot.timeline[0].label = 'tick-2';
+  assert.equal(snapshotCloned.players[0].name, 'Alice');
+  assert.equal(snapshotCloned.ghosts[0].x, 2);
+  assert.equal(snapshotCloned.fruits[0].x, 3);
+  assert.equal(snapshotCloned.sectors[0].captured, false);
+  assert.equal(snapshotCloned.gates[0].open, false);
+  assert.equal(snapshotCloned.pings[0].kind, 'focus');
+  assert.equal(snapshotCloned.events[0].type, 'toast');
+  assert.equal(snapshotCloned.timeline[0].label, 'tick-1');
+
+  const summary = normalizeSummary({
+    reason: 'timeout',
+    durationMs: 1000,
+    captureRatio: 0.5,
+    timeline: [],
+    ranking: [],
+  } as unknown as GameSummary);
+  assert.deepEqual(summary.awards, []);
+
+  const normalizedSnapshot = normalizeSnapshot({
+    ...makeSnapshot(2, 1200),
+    pings: undefined,
+  } as unknown as Snapshot);
+  assert.deepEqual(normalizedSnapshot.pings, []);
+}
+
 function main(): void {
   testFindReplayFrameIndex();
   testParseReplayLog();
   testRejectLegacyFrameShape();
+  testRejectMalformedSnapshotCollections();
+  testAcceptSnapshotWithoutPings();
+  testRejectMalformedWorldCollections();
+  testReplayModelUtilities();
   console.log('[replay_parser.selftest] ok');
 }
 


### PR DESCRIPTION
## Summary
- add `src/client/replay_model.ts` and centralize replay clone/normalize utilities
- remove duplicated replay conversion logic from `src/client/main.ts` and `src/client/replay_parser.ts`
- harden `parseReplayLog` against malformed `world/snapshot` array fields while keeping backward compatibility for missing `snapshot.pings`
- extend `src/client/replay_parser.selftest.ts` with malformed-input and replay-model regression tests
- add development docs under `docs/dev/client-main-modularize/`

## Validation
- `npm run check`
- `npm run build`
- `npm run test`

## Related
- refs #66
